### PR TITLE
Connection Handler: fixing connection leaks [CM-457]

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -10,6 +10,19 @@ class Client {
     this.url = url || process.env.MONGODB_URL;
   }
 
+  static bootstrap(url) {
+    Client.instance = new Client(url);
+    return Client.instance.init();
+  }
+
+  static get() {
+    if (!Client.instance) {
+      throw new Error('Connection pool is not initialized! please, use Client.boostrap()');
+    }
+
+    return Client.instance;
+  }
+
   init() {
     const opts = {};
     if (process.env.MONGODB_POOL_SIZE) {
@@ -32,6 +45,7 @@ class Client {
           retry(err);
         });
       }, retryOptions).then(connection => {
+        logger.debug('Connection Pool is created');
         this.connection = connection;
         this.connection.on('close', this.connectionClosed.bind(this));
         resolve(connection);

--- a/src/client.js
+++ b/src/client.js
@@ -23,6 +23,14 @@ class Client {
     return Client.instance;
   }
 
+  static close() {
+    if (!Client.instance) {
+      return Promise.resolve();
+    }
+
+    return Client.instance.connection.close();
+  }
+
   init() {
     const opts = {};
     if (process.env.MONGODB_POOL_SIZE) {

--- a/src/client.js
+++ b/src/client.js
@@ -1,9 +1,9 @@
-const client = require('mongodb').MongoClient;
 const Promise = require('bluebird');
 const promiseRetry = require('promise-retry');
 
 const QueryBuilder = require('./query-builder');
 const { fixId } = require('./utils');
+const connectionHandler = require('./connection-handler')
 
 class Client {
   constructor(url) {
@@ -26,8 +26,9 @@ class Client {
           logger.info('Attempt %s to connect to MongoDB - %s', number, this.url);
         }
 
-        return client.connect(this.url, opts).catch(err => {
+        return connectionHandler.retrieve_connection(this.url, opts).catch(err => {
           logger.error('Error on attempt %s to connect', number, err);
+          connectionHandler.discard_connection();
           retry(err);
         });
       }, retryOptions).then(connection => {
@@ -40,6 +41,7 @@ class Client {
 
   connectionClosed() {
     this.connection = null;
+    connectionHandler.discard_connection();
   }
 
   connect() {

--- a/src/connection-handler.js
+++ b/src/connection-handler.js
@@ -1,0 +1,20 @@
+const client = require('mongodb').MongoClient;
+
+class ConnectionHandler {
+
+    retrieve_connection(url, opts) {
+        if (this.connectionPromise) {
+            return this.connectionPromise;
+        }
+
+        this.connectionPromise = client.connect(url, opts);
+        return this.connectionPromise;
+    }
+
+    discard_connection() {
+        this.connectionPromise = null;
+    }
+}
+
+const connectionHandler = new ConnectionHandler();
+module.exports = connectionHandler;


### PR DESCRIPTION
Currently, we're creating a connection pool (via MongoClient.connect) and destroying it to every request, based on stress tests using a HTTP benckmarking tool [3], I realized that response 'finish' event wasn't called for some requests (I don't know why and yes, I tried to use other events) adding connection leak.

### Solution propose

Using a connection handler, the runtime application will get only one call to MongoClient.connect and reuse connections.
Currently, the MongoClient Pool design [1] will grow and contract based on the usage pattern, growing connections if there is no available connections and shrinks when a connection is idle. (respecting the pool size limit)

#### Why is it important?

TCP connections is expansive [2] resulting with more memory consumption, RTT, window size (low  throughput) and other networking aspects. So, it's important reuses TCP connections using a connection pool, removing the complexity of manage to open and close connections.

#### Using mongodb-promise client

`client.connection.close()` should be removed, it is not useful and add complexity of manage db connections to developers.
Everything else still amazing, keeping lazy load connection initialization and async design.

```node
const { Client } = require('mongodb-promise');

const bootstrap = () => (req, res, next) => {
  const client = new Client();
  client.init().then(_ => {
    req.instances = { client };
    next();
  });
};
```

[1] https://github.com/mongodb/node-mongodb-native/blob/master/docs/articles/MongoClient.md#mongoclient-connection-pooling
[2] https://upload.wikimedia.org/wikipedia/commons/2/24/TCP_Slow-Start_and_Congestion_Avoidance.svg
[3] https://github.com/giltene/wrk2


@vinioliveira  could you do tests and check if everything will works well. I didn't have time enough to test all situations.